### PR TITLE
feat: 유저 정보 얻기 및 업데이트 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -2,10 +2,12 @@ package com.milktea.main.user.controller;
 
 import com.milktea.main.user.dto.request.UserInfoDTO;
 import com.milktea.main.user.dto.request.UserLoginRequest;
+import com.milktea.main.user.dto.request.UserUpdateRequest;
 import com.milktea.main.user.dto.response.UserInfoResponse;
 import com.milktea.main.user.dto.response.UserLoginResponse;
 import com.milktea.main.user.dto.request.UserRegisterRequest;
 import com.milktea.main.user.dto.response.UserRegisterResponse;
+import com.milktea.main.user.dto.response.UserUpdateResponse;
 import com.milktea.main.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,14 @@ public class UserRestController {
     public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal String email) {
         UserInfoDTO userDTO = new UserInfoDTO(email);
         UserInfoResponse response = userService.getCurrentUser(userDTO);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+
+    @PutMapping("/api/user")
+    public ResponseEntity<?> updateUserInfo(@AuthenticationPrincipal String email, @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
+        UserUpdateRequest.UserUpdateDTO userDTO = userUpdateRequest.userUpdateDTO();
+        UserUpdateResponse response = userService.updateUser(email, userDTO);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -9,6 +9,7 @@ import com.milktea.main.user.dto.request.UserRegisterRequest;
 import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.dto.response.UserUpdateResponse;
 import com.milktea.main.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -39,17 +40,19 @@ public class UserRestController {
 
     //API 명세 상 users가 아님 user임 주의!
     @GetMapping("/api/user")
-    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal String email) {
+    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal String email, HttpServletRequest request) {
         UserInfoDTO userDTO = new UserInfoDTO(email);
-        UserInfoResponse response = userService.getCurrentUser(userDTO);
+        String token = request.getHeader("Authentication");
+        UserInfoResponse response = userService.getCurrentUser(userDTO, token);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
     @PutMapping("/api/user")
-    public ResponseEntity<?> updateUserInfo(@AuthenticationPrincipal String email, @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
+    public ResponseEntity<?> updateUserInfo(@AuthenticationPrincipal String email, @Valid @RequestBody UserUpdateRequest userUpdateRequest, HttpServletRequest request) {
         UserUpdateRequest.UserUpdateDTO userDTO = userUpdateRequest.userUpdateDTO();
-        UserUpdateResponse response = userService.updateUser(email, userDTO);
+        String token = request.getHeader("Authentication");
+        UserUpdateResponse response = userService.updateUser(email, userDTO, token);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -9,16 +9,19 @@ import com.milktea.main.user.dto.request.UserRegisterRequest;
 import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.dto.response.UserUpdateResponse;
 import com.milktea.main.user.service.UserService;
+import com.milktea.main.util.security.BoardUserDetails;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserRestController {
@@ -41,8 +44,10 @@ public class UserRestController {
     }
 
     //API 명세 상 users가 아님 user임 주의!
+    //principal에 String 값을 넣어 AuthenticationPrincipal 사용이 까다로움
     @GetMapping("/api/user")
-    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal String email, HttpServletRequest request) {
+    public ResponseEntity<?> getUserInfo(/*@AuthenticationPrincipal String email)),*/ HttpServletRequest request) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
         UserInfoDTO userDTO = new UserInfoDTO(email);
         String token = request.getHeader("Authentication");
         UserInfoResponse response = userService.getCurrentUser(userDTO, token);

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -1,9 +1,11 @@
 package com.milktea.main.user.controller;
 
-import com.milktea.main.user.dto.UserLoginRequest;
-import com.milktea.main.user.dto.UserLoginResponse;
-import com.milktea.main.user.dto.UserRegisterRequest;
-import com.milktea.main.user.dto.UserRegisterResponse;
+import com.milktea.main.user.dto.request.UserInfoDTO;
+import com.milktea.main.user.dto.request.UserLoginRequest;
+import com.milktea.main.user.dto.response.UserInfoResponse;
+import com.milktea.main.user.dto.response.UserLoginResponse;
+import com.milktea.main.user.dto.request.UserRegisterRequest;
+import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -49,7 +49,7 @@ public class UserRestController {
     public ResponseEntity<?> getUserInfo(/*@AuthenticationPrincipal String email)),*/ HttpServletRequest request) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         UserInfoDTO userDTO = new UserInfoDTO(email);
-        String token = request.getHeader("Authentication");
+        String token = request.getHeader("Authorization");
         UserInfoResponse response = userService.getCurrentUser(userDTO, token);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -58,7 +58,7 @@ public class UserRestController {
     @PutMapping("/api/user")
     public ResponseEntity<?> updateUserInfo(@Valid @RequestBody UserUpdateRequest userUpdateRequest, HttpServletRequest request) {
         UserUpdateRequest.UserUpdateDTO userDTO = userUpdateRequest.userUpdateDTO();
-        String token = request.getHeader("Authentication");
+        String token = request.getHeader("Authorization");
         //토큰을 새로 발급하기 위해서는 email 뿐만 아니라 authority도 필요해서 @AuthenticationPrincipal 안쓰고 직접 가져왔다.
         EmailPasswordAuthentication auth = (EmailPasswordAuthentication) SecurityContextHolder.getContext().getAuthentication();
         UserUpdateResponse response = userService.updateUser(auth, userDTO, token);

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -11,30 +11,35 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
 public class UserRestController {
     private final UserService userService;
 
     //인증 관련 핵심 로직은 InitialAuthenticationFilter에 있음
     //컨트롤러 부분은 단순 User 정보 반환
-    @PostMapping("/login")
+    @PostMapping("/api/users/login")
     public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequest userLoginRequest) {
         UserLoginRequest.UserLoginDTO userDTO = userLoginRequest.userLoginDTO();
         UserLoginResponse response = userService.getLoginUser(userDTO);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PostMapping("")
+    @PostMapping("/api/users")
     public ResponseEntity<?> register(@Valid @RequestBody UserRegisterRequest userRegisterRequest) {
         UserRegisterRequest.UserRegisterDTO userDTO = userRegisterRequest.userRegisterDTO();
         UserRegisterResponse response = userService.registerUser(userDTO);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    //API 명세 상 users가 아님 user임 주의!
+    @GetMapping("/api/user")
+    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal String email) {
+        UserInfoDTO userDTO = new UserInfoDTO(email);
+        UserInfoResponse response = userService.getCurrentUser(userDTO);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/milktea/main/user/controller/UserRestController.java
+++ b/src/main/java/com/milktea/main/user/controller/UserRestController.java
@@ -9,12 +9,14 @@ import com.milktea.main.user.dto.request.UserRegisterRequest;
 import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.dto.response.UserUpdateResponse;
 import com.milktea.main.user.service.UserService;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -49,10 +51,12 @@ public class UserRestController {
 
 
     @PutMapping("/api/user")
-    public ResponseEntity<?> updateUserInfo(@AuthenticationPrincipal String email, @Valid @RequestBody UserUpdateRequest userUpdateRequest, HttpServletRequest request) {
+    public ResponseEntity<?> updateUserInfo(@Valid @RequestBody UserUpdateRequest userUpdateRequest, HttpServletRequest request) {
         UserUpdateRequest.UserUpdateDTO userDTO = userUpdateRequest.userUpdateDTO();
         String token = request.getHeader("Authentication");
-        UserUpdateResponse response = userService.updateUser(email, userDTO, token);
+        //토큰을 새로 발급하기 위해서는 email 뿐만 아니라 authority도 필요해서 @AuthenticationPrincipal 안쓰고 직접 가져왔다.
+        EmailPasswordAuthentication auth = (EmailPasswordAuthentication) SecurityContextHolder.getContext().getAuthentication();
+        UserUpdateResponse response = userService.updateUser(auth, userDTO, token);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/milktea/main/user/dto/request/UserInfoDTO.java
+++ b/src/main/java/com/milktea/main/user/dto/request/UserInfoDTO.java
@@ -1,0 +1,20 @@
+package com.milktea.main.user.dto.request;
+
+import com.google.gson.annotations.SerializedName;
+import com.milktea.main.user.entity.User;
+import lombok.extern.slf4j.Slf4j;
+
+//GET 매핑 DTO
+@Slf4j
+public record UserInfoDTO(
+            String email
+) {
+        public UserInfoDTO{
+            log.debug("UserInfoDTO 생성 - email = {}", email);
+        }
+
+        //테스트 데이터 생성용
+        public UserInfoDTO(User user) {
+            this(user.getEmail());
+        }
+}

--- a/src/main/java/com/milktea/main/user/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/milktea/main/user/dto/request/UserLoginRequest.java
@@ -1,4 +1,4 @@
-package com.milktea.main.user.dto;
+package com.milktea.main.user.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/milktea/main/user/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/milktea/main/user/dto/request/UserRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.milktea.main.user.dto;
+package com.milktea.main.user.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.milktea.main.user.entity.User;

--- a/src/main/java/com/milktea/main/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/milktea/main/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.milktea.main.user.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.milktea.main.user.entity.User;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+
+//수정 가능한 필드만 작성해야 한다.
+@Slf4j
+public record UserUpdateRequest(@JsonProperty("user") @Valid @NotNull UserUpdateDTO userUpdateDTO) {
+    public record UserUpdateDTO(
+            String username,
+            @Email String email,
+            String bio,
+            String image,
+            String password) {
+        public UserUpdateDTO{
+            log.debug("UserUpdateDTO 생성 - username = {}, email = {}", username, email);
+        }
+
+        //테스트 데이터 생성용
+        public UserUpdateDTO(User user) {
+            this(user.getUsername(), user.getEmail(), user.getBio(), user.getImage(), user.getPassword());
+        }
+    }
+}

--- a/src/main/java/com/milktea/main/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.milktea.main.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.milktea.main.user.entity.User;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record UserInfoResponse(@JsonProperty("user") UserInfoDTO userInfoDTO) {
+    public record UserInfoDTO(
+            String email,
+            String token,
+            String username,
+            String bio,
+            String image) {
+        public UserInfoDTO(User user){
+            this(user.getEmail(), null, user.getUsername(), user.getBio(), user.getImage());
+            log.debug("UserInfoDTO 생성 - username = {}, email = {}", username, email);
+        }
+    }
+}

--- a/src/main/java/com/milktea/main/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserInfoResponse.java
@@ -12,8 +12,8 @@ public record UserInfoResponse(@JsonProperty("user") UserInfoDTO userInfoDTO) {
             String username,
             String bio,
             String image) {
-        public UserInfoDTO(User user){
-            this(user.getEmail(), null, user.getUsername(), user.getBio(), user.getImage());
+        public UserInfoDTO(User user, String token){
+            this(user.getEmail(), token, user.getUsername(), user.getBio(), user.getImage());
             log.debug("UserInfoDTO 생성 - username = {}, email = {}", username, email);
         }
     }

--- a/src/main/java/com/milktea/main/user/dto/response/UserLoginResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserLoginResponse.java
@@ -1,11 +1,11 @@
-package com.milktea.main.user.dto;
+package com.milktea.main.user.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.milktea.main.user.entity.User;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public record UserLoginResponse(@JsonProperty("user") UserLoginDTO userRegisterDTO) {
+public record UserLoginResponse(@JsonProperty("user") UserLoginDTO userLoginDTO) {
     public record UserLoginDTO(
             String email,
             String token,
@@ -14,7 +14,7 @@ public record UserLoginResponse(@JsonProperty("user") UserLoginDTO userRegisterD
             String image) {
         public UserLoginDTO(User user){
             this(user.getEmail(), null, user.getUsername(), user.getBio(), user.getImage());
-            log.debug("UserRegisterDTO 생성 - username = {}, email = {}", username, email);
+            log.debug("UserLoginDTO 생성 - username = {}, email = {}", username, email);
         }
     }
 }

--- a/src/main/java/com/milktea/main/user/dto/response/UserRegisterResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserRegisterResponse.java
@@ -1,4 +1,4 @@
-package com.milktea.main.user.dto;
+package com.milktea.main.user.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.milktea.main.user.entity.User;

--- a/src/main/java/com/milktea/main/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserUpdateResponse.java
@@ -12,8 +12,8 @@ public record UserUpdateResponse(@JsonProperty("user") UserUpdateDTO userUpdateD
             String username,
             String bio,
             String image) {
-        public UserUpdateDTO(User user){
-            this(user.getEmail(), null, user.getUsername(), user.getBio(), user.getImage());
+        public UserUpdateDTO(User user, String token){
+            this(user.getEmail(), token, user.getUsername(), user.getBio(), user.getImage());
             log.debug("UserUpdateDTO 생성 - username = {}, email = {}", username, email);
         }
     }

--- a/src/main/java/com/milktea/main/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/milktea/main/user/dto/response/UserUpdateResponse.java
@@ -1,0 +1,20 @@
+package com.milktea.main.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.milktea.main.user.entity.User;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record UserUpdateResponse(@JsonProperty("user") UserUpdateDTO userUpdateDTO) {
+    public record UserUpdateDTO(
+            String email,
+            String token,
+            String username,
+            String bio,
+            String image) {
+        public UserUpdateDTO(User user){
+            this(user.getEmail(), null, user.getUsername(), user.getBio(), user.getImage());
+            log.debug("UserUpdateDTO 생성 - username = {}, email = {}", username, email);
+        }
+    }
+}

--- a/src/main/java/com/milktea/main/user/entity/User.java
+++ b/src/main/java/com/milktea/main/user/entity/User.java
@@ -83,7 +83,7 @@ public class User extends TimestampEntity {
                 //클라이언트에서 보낸 DTO 필드 값이 null이면 수정하는 필드가 아니므로 패스
                 if (Objects.isNull(updateValue)) continue;
 
-                Field field = searchUpdateField(fields, getter);
+                Field field = searchUpdateField(getter);
                 log.debug("업데이트 전 필드 값 - {}", field.get(this));
                 //Record의 getter로 얻은 값을 entity의 field 값으로 변경
                 field.set(this, updateValue);
@@ -95,19 +95,14 @@ public class User extends TimestampEntity {
         }
     }
 
-    private Field searchUpdateField(Field[] fields, Method getter) {
-        for (Field f : fields) {
-            //조건 1 : 필드 이름과 getter 이름 같아야 함
-            if (!f.getName().equals(getter.getName())) continue;
+    private Field searchUpdateField(Method getter) throws Exception {
+        Field field = this.getClass().getDeclaredField(getter.getName());
 
-            //조건 2 : 필드의 타입은 getter와 타입이 같거나 부모타입이어야 한다.
-            if (!getter.getReturnType().isAssignableFrom(f.getType())) continue;
-
-            return f;
+        if (!getter.getReturnType().isAssignableFrom(field.getType())) {
+            log.error("DTO의 타입과 엔티티의 타입이 다름!");
+            throw new RuntimeException("User에서 update할 필드를 찾지 못했습니다.");
         }
 
-        log.error("클라이언트가 전송한 Update할 필드를 엔티티에서 찾을 수 없음!");
-        if (log.isDebugEnabled()) log.debug("Update할 수 없는 DTO 필드 - {}", getter.getName());
-        throw new RuntimeException("User에서 update할 필드를 찾지 못했습니다.");
+        return field;
     }
 }

--- a/src/main/java/com/milktea/main/user/entity/User.java
+++ b/src/main/java/com/milktea/main/user/entity/User.java
@@ -1,17 +1,25 @@
 package com.milktea.main.user.entity;
 
+import com.milktea.main.user.dto.request.UserUpdateRequest;
 import com.milktea.main.util.TimestampEntity;
+import com.milktea.main.util.exceptions.ExceptionUtils;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Entity
 @Getter
 @Table(name = "user_tb")
@@ -58,5 +66,48 @@ public class User extends TimestampEntity {
     public void addAuthority(Authority authority) {
         authority.setUser(this);
         authorities.add(authority);
+    }
+
+    public void updateUser(UserUpdateRequest.UserUpdateDTO userRequest) {
+        //Record Component를 얻고 각각의 Component에서 getAccessor를 호출하여 getter 얻기
+        List<Method> getters = Arrays.stream(userRequest.getClass().getRecordComponents())
+                .map(RecordComponent::getAccessor)
+                .toList();
+
+        //Entity와 DTO getter를 매핑하기 위해 Entity Field를 reflection으로 가져옴
+        Field[] fields = this.getClass().getDeclaredFields();
+
+        try {
+            for (Method getter : getters) {
+                String updateValue = (String) getter.invoke(userRequest);
+                //클라이언트에서 보낸 DTO 필드 값이 null이면 수정하는 필드가 아니므로 패스
+                if (Objects.isNull(updateValue)) continue;
+
+                Field field = searchUpdateField(fields, getter);
+                log.debug("업데이트 전 필드 값 - {}", field.get(this));
+                //Record의 getter로 얻은 값을 entity의 field 값으로 변경
+                field.set(this, updateValue);
+                log.debug("업데이트 후 필드 값 - {}", field.get(this));
+            }
+        } catch (Exception e) {
+            log.error("DTO 메서드를 가져오는 중 문제가 생겼습니다.");
+            if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
+        }
+    }
+
+    private Field searchUpdateField(Field[] fields, Method getter) {
+        for (Field f : fields) {
+            //조건 1 : 필드 이름과 getter 이름 같아야 함
+            if (!f.getName().equals(getter.getName())) continue;
+
+            //조건 2 : 필드의 타입은 getter와 타입이 같거나 부모타입이어야 한다.
+            if (!getter.getReturnType().isAssignableFrom(f.getType())) continue;
+
+            return f;
+        }
+
+        log.error("클라이언트가 전송한 Update할 필드를 엔티티에서 찾을 수 없음!");
+        if (log.isDebugEnabled()) log.debug("Update할 수 없는 DTO 필드 - {}", getter.getName());
+        throw new RuntimeException("User에서 update할 필드를 찾지 못했습니다.");
     }
 }

--- a/src/main/java/com/milktea/main/user/service/UserService.java
+++ b/src/main/java/com/milktea/main/user/service/UserService.java
@@ -76,6 +76,19 @@ public class UserService {
         return new UserLoginResponse(new UserLoginResponse.UserLoginDTO(findUser.get()));
     }
 
+    public UserInfoResponse getCurrentUser(UserInfoDTO userRequest) {
+        String currentUserEmail = userRequest.email();
+
+        Optional<User> findUser = userRepository.findByEmail(currentUserEmail);
+
+        if (findUser.isEmpty()) {
+            log.error("인증을 통과한 유저의 정보를 데이터베이스에서 찾을 수 없습니다. 즉시 원인을 파악해야 합니다.");
+            throw new RuntimeException("사용자 정보를 찾는 중 문제가 발생하였습니다.");
+        }
+
+        return new UserInfoResponse(new UserInfoResponse.UserInfoDTO(findUser.get()));
+    }
+
     private void checkDuplicateUsername(UserRegisterRequest.UserRegisterDTO userRequest) {
         String registerUsername = userRequest.username();
         if (userRepository.findByUsername(registerUsername).isPresent())

--- a/src/main/java/com/milktea/main/user/service/UserService.java
+++ b/src/main/java/com/milktea/main/user/service/UserService.java
@@ -99,10 +99,10 @@ public class UserService {
     @Transactional
     public UserUpdateResponse updateUser(Authentication auth, UserUpdateRequest.UserUpdateDTO userRequest, String token) {
         //수정하려는 email이 이미 가입된 email인지 확인
-        if (Objects.nonNull(userRequest.email())) checkDuplicateUsername(userRequest.username());
+        if (Objects.nonNull(userRequest.email())) checkDuplicateEmail(userRequest.email());
 
         //수정하려는 username이 이미 가입된 username인지 확인
-        if (Objects.nonNull(userRequest.username())) checkDuplicateEmail(userRequest.email());
+        if (Objects.nonNull(userRequest.username())) checkDuplicateUsername(userRequest.username());
 
         Optional<User> findUserOp = userRepository.findByEmail(auth.getName());
         if (findUserOp.isEmpty()) throwUserNotFoundException();

--- a/src/main/java/com/milktea/main/user/service/UserService.java
+++ b/src/main/java/com/milktea/main/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.milktea.main.user.service;
 
-import com.milktea.main.user.dto.UserLoginRequest;
-import com.milktea.main.user.dto.UserLoginResponse;
-import com.milktea.main.user.dto.UserRegisterRequest;
-import com.milktea.main.user.dto.UserRegisterResponse;
+import com.milktea.main.user.dto.request.UserInfoDTO;
+import com.milktea.main.user.dto.request.UserLoginRequest;
+import com.milktea.main.user.dto.response.UserInfoResponse;
+import com.milktea.main.user.dto.response.UserLoginResponse;
+import com.milktea.main.user.dto.request.UserRegisterRequest;
+import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.entity.Authority;
 import com.milktea.main.user.entity.User;
 import com.milktea.main.user.repository.AuthorityRepository;

--- a/src/main/java/com/milktea/main/util/exceptions/JwtAuthenticationException.java
+++ b/src/main/java/com/milktea/main/util/exceptions/JwtAuthenticationException.java
@@ -1,0 +1,9 @@
+package com.milktea.main.util.exceptions;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/milktea/main/util/exceptions/ValidationException.java
+++ b/src/main/java/com/milktea/main/util/exceptions/ValidationException.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 
-//당장은 사용하지 않고 잠시 보류
 @Getter
 @AllArgsConstructor
 public class ValidationException extends RuntimeException {

--- a/src/main/java/com/milktea/main/util/security/BoardUserDetails.java
+++ b/src/main/java/com/milktea/main/util/security/BoardUserDetails.java
@@ -25,10 +25,11 @@ public class BoardUserDetails implements UserDetails {
         return user.getPassword();
     }
 
+    //이메일 기반 인증이므로 email 반환
     @Override
     public String getUsername() {
 
-        return user.getUsername();
+        return user.getEmail();
     }
 
     @Override

--- a/src/main/java/com/milktea/main/util/security/BoardUserDetails.java
+++ b/src/main/java/com/milktea/main/util/security/BoardUserDetails.java
@@ -28,7 +28,6 @@ public class BoardUserDetails implements UserDetails {
     //이메일 기반 인증이므로 email 반환
     @Override
     public String getUsername() {
-
         return user.getEmail();
     }
 

--- a/src/main/java/com/milktea/main/util/security/EmailPasswordAuthenticationProvider.java
+++ b/src/main/java/com/milktea/main/util/security/EmailPasswordAuthenticationProvider.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,7 +36,7 @@ public class EmailPasswordAuthenticationProvider implements AuthenticationProvid
 
         //비밀번호 맞으면
         if (checkPasswordResult) {
-            return new UsernamePasswordAuthenticationToken(
+            return new EmailPasswordAuthentication(
                     user.getUsername(),
                     user.getPassword(),
                     user.getAuthorities());

--- a/src/main/java/com/milktea/main/util/security/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/milktea/main/util/security/config/EmbeddedRedisConfig.java
@@ -28,10 +28,6 @@ public class EmbeddedRedisConfig {
                 .port(redisPort)
                 .setting("maxmemory 128M")
                 .build();
-    }
-
-    @PostConstruct
-    public void postConstruct() {
         redisServer.start();
     }
 

--- a/src/main/java/com/milktea/main/util/security/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/milktea/main/util/security/config/EmbeddedRedisConfig.java
@@ -1,0 +1,42 @@
+package com.milktea.main.util.security.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@Slf4j
+@Profile("test")
+@Configuration
+public class EmbeddedRedisConfig {
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        redisServer = RedisServer.builder()
+                .port(redisPort)
+                .setting("maxmemory 128M")
+                .build();
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        redisServer.stop();
+    }
+}

--- a/src/main/java/com/milktea/main/util/security/config/RedisConfig.java
+++ b/src/main/java/com/milktea/main/util/security/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.milktea.main.util.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableRedisRepositories(basePackages = "com.milktea.main")
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/milktea/main/util/security/config/SecurityFilterConfig.java
+++ b/src/main/java/com/milktea/main/util/security/config/SecurityFilterConfig.java
@@ -14,8 +14,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
-import static com.milktea.main.util.security.JwtAuthenticationWhiteList.ALL_METHOD_WHITELIST;
-import static com.milktea.main.util.security.JwtAuthenticationWhiteList.SPECIFIC_METHOD_WHITELIST;
+import static com.milktea.main.util.security.jwt.JwtAuthenticationWhiteList.ALL_METHOD_WHITELIST;
+import static com.milktea.main.util.security.jwt.JwtAuthenticationWhiteList.SPECIFIC_METHOD_WHITELIST;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/milktea/main/util/security/config/TimeConfig.java
+++ b/src/main/java/com/milktea/main/util/security/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.milktea.main.util.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
@@ -5,41 +5,32 @@ import com.milktea.main.user.dto.request.UserLoginRequest;
 import com.milktea.main.util.exceptions.ExceptionUtils;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import com.milktea.main.util.security.LoginHttpServletRequestWrapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.crypto.SecretKey;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Date;
 import java.util.Objects;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class InitialAuthenticationFilter extends OncePerRequestFilter {
-    public static final String AUTHORITY_DELIMITER = ",";
 
     private final AuthenticationManager manager;
 
-    @Value("${jwt.signing.key}")
-    private final String signingKey;
+    private final JwtTokenAdministrator jwtTokenAdministrator;
+
 
     //"/api/users/login"의 요청을 이 필터가 가로챈다.
     //AuthenticationManager가 Authentication을 검증한다.
@@ -65,31 +56,7 @@ public class InitialAuthenticationFilter extends OncePerRequestFilter {
             Authentication authentication = new EmailPasswordAuthentication(email, password);
             Authentication returnAuthentication = manager.authenticate(authentication);
 
-            SecretKey key = Keys.hmacShaKeyFor(
-                signingKey.getBytes(StandardCharsets.UTF_8)
-        );
-
-            log.debug("AuthenticationManager가 반환한 username - {}", returnAuthentication.getName());
-            log.debug("AuthenticationManager가 반환한 authorities - {}", returnAuthentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).reduce((a, b) -> a + b));
-
-            Claims claims = Jwts.claims()
-                .setIssuedAt(new Date());
-
-            claims.put("email", email);
-            Collection<? extends GrantedAuthority> grantedAuthorities = returnAuthentication.getAuthorities();
-
-            claims.put("authorities",
-                String.join(AUTHORITY_DELIMITER,
-                grantedAuthorities.stream()
-                        .map(GrantedAuthority::getAuthority)
-                        .toList()
-                )
-        );
-
-            String jwt = Jwts.builder()
-                .setClaims(claims) //JWT와 관련된 정보 입력
-                .signWith(key) //서명 키는 실제로 사용자별로 다른 키를 사용해야 한다.
-                .compact();
+            String jwt = jwtTokenAdministrator.issueToken(email, returnAuthentication);
 
             response.setHeader("Authorization", jwt);
 

--- a/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
@@ -20,6 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.time.Instant;
 import java.util.Objects;
 
 @Component

--- a/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
@@ -1,8 +1,7 @@
 package com.milktea.main.util.security.filter;
 
 import com.google.gson.Gson;
-import com.milktea.main.user.dto.UserLoginRequest;
-import com.milktea.main.util.exceptions.ErrorResponse;
+import com.milktea.main.user.dto.request.UserLoginRequest;
 import com.milktea.main.util.exceptions.ExceptionUtils;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import com.milktea.main.util.security.LoginHttpServletRequestWrapper;
@@ -29,7 +28,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 @Component

--- a/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/InitialAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class InitialAuthenticationFilter extends OncePerRequestFilter {
             Authentication authentication = new EmailPasswordAuthentication(email, password);
             Authentication returnAuthentication = manager.authenticate(authentication);
 
-            String jwt = jwtTokenAdministrator.issueToken(email, returnAuthentication);
+            String jwt = jwtTokenAdministrator.issueToken(returnAuthentication);
 
             response.setHeader("Authorization", jwt);
 

--- a/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
@@ -39,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String jwt = request.getHeader("Authorization");
+        String parsingJwt = jwt.replaceFirst("Token ", "");
 
         //서명된 Jwt를 풀기 위한 Secret Key 생성
         SecretKey key = Keys.hmacShaKeyFor(
@@ -49,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(key) //서명 검증을 위한 SecretKey 입력
                 .build()
-                .parseClaimsJws(jwt) //토큰이 유효한지 검사. 유효하지 않으면 여러 종류 예외 발생
+                .parseClaimsJws(parsingJwt) //토큰이 유효한지 검사. 유효하지 않으면 여러 종류 예외 발생
                 .getBody();
 
         String email = String.valueOf(claims.get("email"));
@@ -65,6 +66,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 authorities
         );
 
+        //이 때 담은 auth는 호출된 메서드가 종료될 때 까지 유효하다 -> sessionless를 사용헀기 때문에 영속화는 안됨
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String email = String.valueOf(claims.get("email"));
 
         //하나의 String으로 되어있는 Claims.get("authorities")에 "AUTHORITY1, AUTHORITY2"를 분리하여 List<? extends GrantedAuthority>로 만든다.
-        List<? extends GrantedAuthority> authorities = Arrays.stream(((String)claims.get("authorities")).split(JwtTokenAdministrator.authorityDelimiter()))
+        List<? extends GrantedAuthority> authorities = Arrays.stream(((String)claims.get("authorities")).split(JwtTokenAdministrator.AUTHORITY_DELIMITER))
                 .map(SimpleGrantedAuthority::new)
                 .toList();
 

--- a/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
@@ -4,15 +4,12 @@ package com.milktea.main.util.security.filter;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -21,9 +18,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.crypto.SecretKey;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -34,7 +29,6 @@ import static com.milktea.main.util.security.jwt.JwtAuthenticationWhiteList.SPEC
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
     private final JwtTokenAdministrator jwtTokenAdministrator;
 
     @Override

--- a/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/milktea/main/util/security/filter/JwtAuthenticationFilter.java
@@ -34,8 +34,6 @@ import static com.milktea.main.util.security.jwt.JwtAuthenticationWhiteList.SPEC
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    @Value("${jwt.signing.key}")
-    private final String signingKey;
 
     private final JwtTokenAdministrator jwtTokenAdministrator;
 

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtAuthenticationWhiteList.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtAuthenticationWhiteList.java
@@ -1,4 +1,4 @@
-package com.milktea.main.util.security;
+package com.milktea.main.util.security.jwt;
 
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
@@ -1,6 +1,7 @@
 package com.milktea.main.util.security.jwt;
 
 import com.milktea.main.util.exceptions.ExceptionUtils;
+import com.milktea.main.util.exceptions.JwtAuthenticationException;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -11,8 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -119,7 +120,7 @@ public class JwtTokenAdministrator {
         return true;
     }
 
-    private Claims parseJwtToken(SecretKey key, String parsingJwt) throws ServletException {
+    private Claims parseJwtToken(SecretKey key, String parsingJwt) {
         //JWT에서 정보 얻기(모든 예외는 여기서 로그만 남기고 ExceptionHandlingFilter가 UNAUTHORIZED로 처리할 것)
         Claims claims;
         try {
@@ -135,22 +136,22 @@ public class JwtTokenAdministrator {
         catch (ExpiredJwtException e) {
             log.warn("Jwt token이 만료되어 접근할 수 없음!");
             if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
-            throw new ServletException("로그인 시간이 만료되었습니다. 다시 로그인해주세요.");
+            throw new JwtAuthenticationException("로그인 시간이 만료되었습니다. 다시 로그인해주세요.", e);
         }
         catch (SignatureException e) {
             log.warn("유효하지 않은 인증으로 접근 시도!");
             if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
-            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+            throw new JwtAuthenticationException("인증에 실패하였습니다. 다시 로그인해주세요.", e);
         }
         catch (MalformedJwtException | UnsupportedJwtException e) {
             log.warn("잘못된 jwt 형식 받음!");
             if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
-            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+            throw new JwtAuthenticationException("인증에 실패하였습니다. 다시 로그인해주세요.", e);
         }
         catch (Exception e) {
             log.warn("jwt 파싱 과정에서 예외 발생!");
             if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
-            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+            throw new JwtAuthenticationException("인증에 실패하였습니다. 다시 로그인해주세요.", e);
         }
 
         return claims;

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 public class JwtTokenAdministrator {
     private static final long TOKEN_EXPIRATION_SECONDS = 3600L;
 
-    private static final String AUTHORITY_DELIMITER = ",";
+    public static final String AUTHORITY_DELIMITER = ",";
 
     @Value("${jwt.signing.key}")
     private final String signingKey;
@@ -38,11 +38,6 @@ public class JwtTokenAdministrator {
     private final JwtTokenBlackListRepository jwtTokenBlackListRepository;
 
     private final Clock clock;
-
-
-    public static String authorityDelimiter() {
-        return AUTHORITY_DELIMITER;
-    }
 
     public String issueToken(Authentication returnAuthentication){
         SecretKey key = Keys.hmacShaKeyFor(

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
@@ -1,15 +1,21 @@
 package com.milktea.main.util.security.jwt;
 
 import com.milktea.main.util.exceptions.ExceptionUtils;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.ServletException;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -17,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -29,11 +36,13 @@ public class JwtTokenAdministrator {
     @Value("${jwt.signing.key}")
     private final String signingKey;
 
+    private final JwtTokenBlackListRepository jwtTokenBlackListRepository;
+
     public static String authorityDelimiter() {
         return AUTHORITY_DELIMITER;
     }
 
-    public String issueToken(String email, Authentication returnAuthentication){
+    public String issueToken(Authentication returnAuthentication){
         SecretKey key = Keys.hmacShaKeyFor(
                 signingKey.getBytes(StandardCharsets.UTF_8)
         );
@@ -46,7 +55,9 @@ public class JwtTokenAdministrator {
         Claims claims = Jwts.claims()
                 .setExpiration(Date.from(expiredInstant));
 
+        String email = returnAuthentication.getName();
         claims.put("email", email);
+
         Collection<? extends GrantedAuthority> grantedAuthorities = returnAuthentication.getAuthorities();
 
         claims.put("authorities",
@@ -73,10 +84,41 @@ public class JwtTokenAdministrator {
                 signingKey.getBytes(StandardCharsets.UTF_8)
         );
 
-        return parseJwtToken(key, parsingJwt);
+        Claims claims = parseJwtToken(key, parsingJwt);
+
+        //만약 블랙리스트에 포함된 토큰이라면 예외 발생시키기
+        String email = claims.get("Email", String.class);
+        Optional<JwtTokenBlackList> blackListTokenOp = jwtTokenBlackListRepository.findById(email);
+        //블랙리스트에 없으면 검증 완료
+        if (blackListTokenOp.isEmpty()) return claims;
+
+        //블랙리스트에 있으면
+        String blackListToken = blackListTokenOp.get().getTokenValue();
+        if (blackListToken.equals(parsingJwt)) throw new BadCredentialsException("유효하지 않은 토큰입니다.");
+        else return claims;
     }
 
-    public Claims parseJwtToken(SecretKey key, String parsingJwt) throws ServletException {
+    public String updateToken(String email, String oldJwt) {
+        //이메일 변경 시 기존 토큰 만료시키기
+        EmailPasswordAuthentication auth = (EmailPasswordAuthentication) SecurityContextHolder.getContext().getAuthentication();
+        String oldEmail = auth.getName();
+
+        String parsingOldJwt = oldJwt.replaceFirst("Token ", "");
+        if (!emailCanChange()) throw new RuntimeException("현재 이메일을 변경할 수 없습니다.");
+        jwtTokenBlackListRepository.save(new JwtTokenBlackList(oldEmail, parsingOldJwt));
+
+        //새 토큰 발급
+        return issueToken(new EmailPasswordAuthentication(email, null, auth.getAuthorities()));
+    }
+
+    //이메일을 너무 자주 발급받아 블랙리스트에 토큰이 계속 갱신되는 것을 막기 위해 이메일 변경 기간을 둠
+    //토큰 만료 기한(redis ttl 기한)보다 이메일 변경 가능 기한을 훨씬 길게 설정
+    private boolean emailCanChange() {
+        //리팩토링 필요
+        return true;
+    }
+
+    private Claims parseJwtToken(SecretKey key, String parsingJwt) throws ServletException {
         //JWT에서 정보 얻기(모든 예외는 여기서 로그만 남기고 ExceptionHandlingFilter가 UNAUTHORIZED로 처리할 것)
         Claims claims;
         try {
@@ -110,7 +152,5 @@ public class JwtTokenAdministrator {
         return claims;
     }
 
-    public String updateToken(String email, String token) {
 
-    }
 }

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenAdministrator.java
@@ -1,0 +1,116 @@
+package com.milktea.main.util.security.jwt;
+
+import com.milktea.main.util.exceptions.ExceptionUtils;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.ServletException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtTokenAdministrator {
+    private static final long TOKEN_EXPIRATION_SECONDS = 3600L;
+
+    private static final String AUTHORITY_DELIMITER = ",";
+
+    @Value("${jwt.signing.key}")
+    private final String signingKey;
+
+    public static String authorityDelimiter() {
+        return AUTHORITY_DELIMITER;
+    }
+
+    public String issueToken(String email, Authentication returnAuthentication){
+        SecretKey key = Keys.hmacShaKeyFor(
+                signingKey.getBytes(StandardCharsets.UTF_8)
+        );
+
+        log.debug("AuthenticationManager가 반환한 username - {}", returnAuthentication.getName());
+        log.debug("AuthenticationManager가 반환한 authorities - {}", returnAuthentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).reduce((a, b) -> a + b));
+
+        //만료 기한 추가
+        Instant expiredInstant = Instant.now().plusSeconds(1800L);
+        Claims claims = Jwts.claims()
+                .setExpiration(Date.from(expiredInstant));
+
+        claims.put("email", email);
+        Collection<? extends GrantedAuthority> grantedAuthorities = returnAuthentication.getAuthorities();
+
+        claims.put("authorities",
+                String.join(AUTHORITY_DELIMITER,
+                        grantedAuthorities.stream()
+                                .map(GrantedAuthority::getAuthority)
+                                .toList()
+                )
+        );
+
+        String jwt = Jwts.builder()
+                .setClaims(claims) //JWT와 관련된 정보 입력
+                .signWith(key) //서명 키는 실제로 사용자별로 다른 키를 사용해야 한다.
+                .compact();
+
+        return jwt;
+    }
+
+    public Claims verifyToken(String jwt) throws ServletException {
+        String parsingJwt = jwt.replaceFirst("Token ", "");
+
+        //서명된 Jwt를 풀기 위한 Secret Key 생성
+        SecretKey key = Keys.hmacShaKeyFor(
+                signingKey.getBytes(StandardCharsets.UTF_8)
+        );
+
+        return parseJwtToken(key, parsingJwt);
+    }
+
+    public Claims parseJwtToken(SecretKey key, String parsingJwt) throws ServletException {
+        //JWT에서 정보 얻기(모든 예외는 여기서 로그만 남기고 ExceptionHandlingFilter가 UNAUTHORIZED로 처리할 것)
+        Claims claims;
+        try {
+            claims = Jwts.parserBuilder()
+                    .setSigningKey(key) //서명 검증을 위한 SecretKey 입력
+                    .build()
+                    .parseClaimsJws(parsingJwt) //토큰이 유효한지 검사. 유효하지 않으면 여러 종류 예외 발생
+                    .getBody();
+        }
+        catch (ExpiredJwtException e) {
+            log.warn("Jwt token이 만료되어 접근할 수 없음!");
+            if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
+            throw new ServletException("로그인 시간이 만료되었습니다. 다시 로그인해주세요.");
+        }
+        catch (SignatureException e) {
+            log.warn("유효하지 않은 인증으로 접근 시도!");
+            if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
+            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+        }
+        catch (MalformedJwtException | UnsupportedJwtException e) {
+            log.warn("잘못된 jwt 형식 받음!");
+            if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
+            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+        }
+        catch (Exception e) {
+            log.warn("jwt 파싱 과정에서 예외 발생!");
+            if (log.isDebugEnabled()) log.debug(ExceptionUtils.getStackTrace(e));
+            throw new ServletException("인증에 실패하였습니다. 다시 로그인해주세요.");
+        }
+
+        return claims;
+    }
+
+    public String updateToken(String email, String token) {
+
+    }
+}

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackList.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackList.java
@@ -1,19 +1,19 @@
 package com.milktea.main.util.security.jwt;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @RedisHash(value = "tokenBlackList", timeToLive = 3600L) //timeToLive는 토큰의 만료시간과 동일하게
 public class JwtTokenBlackList {
     @Id
     private String email; //hash의 key가 됨(전체 키 값 -> RedisHash의 value + id의 값)
 
     private String tokenValue;
-
-    public JwtTokenBlackList(String email, String tokenValue) {
-        this.email = email;
-        this.tokenValue = tokenValue;
-    }
 }

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackList.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackList.java
@@ -1,0 +1,19 @@
+package com.milktea.main.util.security.jwt;
+
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "tokenBlackList", timeToLive = 3600L) //timeToLive는 토큰의 만료시간과 동일하게
+public class JwtTokenBlackList {
+    @Id
+    private String email; //hash의 key가 됨(전체 키 값 -> RedisHash의 value + id의 값)
+
+    private String tokenValue;
+
+    public JwtTokenBlackList(String email, String tokenValue) {
+        this.email = email;
+        this.tokenValue = tokenValue;
+    }
+}

--- a/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepository.java
+++ b/src/main/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepository.java
@@ -1,0 +1,8 @@
+package com.milktea.main.util.security.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JwtTokenBlackListRepository extends CrudRepository<JwtTokenBlackList, String> {
+}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -9,5 +9,9 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.default_batch_fetch_size=10
 spring.jpa.properties.hibernate.format_sql=true
 
+## redis
+spring.data.redis.port=6379
+spring.data.redis.host=localhost
+
 # jwt
 jwt.signing.key = adsfasfasfasdfasdfasfasdfasfasdfasdfasfdasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasfd

--- a/src/test/java/com/milktea/main/ApplicationTests.java
+++ b/src/test/java/com/milktea/main/ApplicationTests.java
@@ -3,7 +3,7 @@ package com.milktea.main;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ApplicationTests {
 
 	@Test

--- a/src/test/java/com/milktea/main/factory/MockSecurityContextFactory.java
+++ b/src/test/java/com/milktea/main/factory/MockSecurityContextFactory.java
@@ -1,0 +1,52 @@
+package com.milktea.main.factory;
+
+import com.milktea.main.user.entity.Authority;
+import com.milktea.main.user.entity.User;
+import com.milktea.main.util.exceptions.ExceptionUtils;
+import com.milktea.main.util.security.BoardUserDetails;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+@Slf4j
+public class MockSecurityContextFactory implements WithSecurityContextFactory<WithCustomUser> {
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.getContext();
+
+        UserMother.UserBuilder userBuilder = UserMother.user();
+
+        //하드코딩 해버림
+        //현재 API는 고정되어 있기도 하고 리플렉션으로 구현하기에는 비밀번호 인코딩과 배열(authority)과 같은 특수한 상황도 고려해야함
+        if (!annotation.email().isBlank()) userBuilder.withEmail(annotation.email());
+        if (!annotation.password().isBlank()) userBuilder.withPassword(annotation.password(), passwordEncoder);
+        if (!annotation.bio().isBlank()) userBuilder.withBio(annotation.bio());
+        if (!annotation.image().isBlank()) userBuilder.withBio(annotation.image());
+        if (annotation.authority().length != 0) userBuilder.withAuthorities(Arrays.stream(annotation.authority())
+                .map(Authority::new)
+                .toList());
+
+
+        BoardUserDetails boardUserDetails = new BoardUserDetails(userBuilder.build());
+        Authentication auth = new EmailPasswordAuthentication(boardUserDetails.getUsername(),
+                boardUserDetails.getPassword(),
+                boardUserDetails.getAuthorities());
+
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/src/test/java/com/milktea/main/factory/UserMother.java
+++ b/src/test/java/com/milktea/main/factory/UserMother.java
@@ -37,6 +37,16 @@ public class UserMother {
             return this;
         }
 
+        public UserBuilder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public UserBuilder withBio(String bio) {
+            this.bio = bio;
+            return this;
+        }
+
         public User build() {
             User returnUser = new User(
                     email,

--- a/src/test/java/com/milktea/main/factory/UserMother.java
+++ b/src/test/java/com/milktea/main/factory/UserMother.java
@@ -42,6 +42,11 @@ public class UserMother {
             return this;
         }
 
+        public UserBuilder withUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
         public UserBuilder withBio(String bio) {
             this.bio = bio;
             return this;

--- a/src/test/java/com/milktea/main/factory/WithCustomUser.java
+++ b/src/test/java/com/milktea/main/factory/WithCustomUser.java
@@ -1,0 +1,19 @@
+package com.milktea.main.factory;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = MockSecurityContextFactory.class)
+public @interface WithCustomUser {
+    String email() default "";
+    String password() default "";
+
+    String bio() default "";
+
+    String image() default "";
+    String[] authority() default {};
+}

--- a/src/test/java/com/milktea/main/user/controller/UserControllerTest.java
+++ b/src/test/java/com/milktea/main/user/controller/UserControllerTest.java
@@ -287,10 +287,10 @@ public class UserControllerTest {
 
             //출력할 객체 생성
             User user = UserMother.user().build();
-            UserInfoResponse response = new UserInfoResponse(new UserInfoResponse.UserInfoDTO(user));
+            UserInfoResponse response = new UserInfoResponse(new UserInfoResponse.UserInfoDTO(user, "test token"));
 
             //mock 정의
-            when(mockUserService.getCurrentUser(any())).thenReturn(response);
+            when(mockUserService.getCurrentUser(any(), any())).thenReturn(response);
 
             //when
             final ResultActions actions = mockMvc.perform(

--- a/src/test/java/com/milktea/main/user/controller/UserControllerTest.java
+++ b/src/test/java/com/milktea/main/user/controller/UserControllerTest.java
@@ -1,8 +1,9 @@
 package com.milktea.main.user.controller;
 
 import com.milktea.main.factory.UserMother;
-import com.milktea.main.user.dto.UserLoginResponse;
-import com.milktea.main.user.dto.UserRegisterResponse;
+import com.milktea.main.user.dto.response.UserInfoResponse;
+import com.milktea.main.user.dto.response.UserLoginResponse;
+import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.entity.User;
 import com.milktea.main.user.service.UserService;
 import com.milktea.main.util.exceptions.GlobalExceptionHandler;
@@ -27,6 +28,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -263,6 +265,36 @@ public class UserControllerTest {
                             .accept(MediaType.APPLICATION_JSON)
                             .characterEncoding("UTF-8")
                             .content(jsonString));
+
+
+            //then
+            log.debug("출력 JSON - {}", actions.andReturn().getResponse().getContentAsString());
+
+            actions
+                    .andExpect(jsonPath("user.username").value("newUser"))
+                    .andExpect(jsonPath("user.email").value("newUser@naver.com"));
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 얻기(GET /api/user)")
+    class GetUser{
+        private static final String GET_USER_URL = "/api/user";
+        @Test
+        @DisplayName("성공 테스트")
+        void login_success_test() throws Exception {
+            //given
+
+            //출력할 객체 생성
+            User user = UserMother.user().build();
+            UserInfoResponse response = new UserInfoResponse(new UserInfoResponse.UserInfoDTO(user));
+
+            //mock 정의
+            when(mockUserService.getCurrentUser(any())).thenReturn(response);
+
+            //when
+            final ResultActions actions = mockMvc.perform(
+                    get(GET_USER_URL));
 
 
             //then

--- a/src/test/java/com/milktea/main/user/service/UserServiceTest.java
+++ b/src/test/java/com/milktea/main/user/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import com.milktea.main.user.entity.User;
 import com.milktea.main.user.repository.AuthorityRepository;
 import com.milktea.main.user.repository.UserRepository;
 import com.milktea.main.util.exceptions.ValidationException;
+import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -27,11 +28,16 @@ import static org.mockito.Mockito.when;
 public class UserServiceTest {
     private static User user;
 
+    private static UserService userService;
+
     private static UserRepository userRepository;
 
     private static AuthorityRepository authorityRepository;
 
     private static PasswordEncoder passwordEncoder;
+
+    private static JwtTokenAdministrator jwtTokenAdministrator;
+
 
 
     @BeforeEach
@@ -40,6 +46,7 @@ public class UserServiceTest {
         userRepository = Mockito.mock(UserRepository.class);
         authorityRepository = Mockito.mock(AuthorityRepository.class);
         passwordEncoder = new BCryptPasswordEncoder();
+        UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository, jwtTokenAdministrator);
     }
 
     @Nested
@@ -49,7 +56,6 @@ public class UserServiceTest {
         @DisplayName("성공 테스트")
         void register_user_success_test() {
             //given
-            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
             UserRegisterRequest.UserRegisterDTO userRegisterRequest = new UserRegisterRequest.UserRegisterDTO(user);
 
             //when
@@ -66,7 +72,6 @@ public class UserServiceTest {
         @DisplayName("중복된 username 실패 테스트")
         void register_user_duplicate_username_fail_test() {
             //given
-            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
             UserRegisterRequest.UserRegisterDTO userRegisterRequest = new UserRegisterRequest.UserRegisterDTO(user);
 
             //when
@@ -81,7 +86,6 @@ public class UserServiceTest {
         @DisplayName("중복된 email 실패 테스트")
         void register_user_duplicate_email_fail_test() {
             //given
-            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
             UserRegisterRequest.UserRegisterDTO userRegisterRequest = new UserRegisterRequest.UserRegisterDTO(user);
 
             //when
@@ -100,7 +104,6 @@ public class UserServiceTest {
         @DisplayName("성공 테스트")
         void login_user_success_test() {
             //given
-            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
             UserLoginRequest.UserLoginDTO userLoginRequest = new UserLoginRequest.UserLoginDTO(user);
 
             //when
@@ -121,19 +124,17 @@ public class UserServiceTest {
         @DisplayName("성공 테스트")
         void get_user_success_test() {
             //given
-            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
             UserInfoDTO userInfoRequest = new UserInfoDTO(user);
 
             //when
             when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
             when(userRepository.save(any())).thenReturn(user);
-            UserInfoResponse result = userService.getCurrentUser(userInfoRequest);
+            UserInfoResponse result = userService.getCurrentUser(userInfoRequest, "test token");
 
 
             //then
             Assertions.assertEquals("newUser", result.userInfoDTO().username());
         }
     }
-
 
 }

--- a/src/test/java/com/milktea/main/user/service/UserServiceTest.java
+++ b/src/test/java/com/milktea/main/user/service/UserServiceTest.java
@@ -93,8 +93,47 @@ public class UserServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("로그인(POST /api/users/login)")
+    class Login {
+        @Test
+        @DisplayName("성공 테스트")
+        void login_user_success_test() {
+            //given
+            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
+            UserLoginRequest.UserLoginDTO userLoginRequest = new UserLoginRequest.UserLoginDTO(user);
+
+            //when
+            when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
+            when(userRepository.save(any())).thenReturn(user);
+            UserLoginResponse result = userService.getLoginUser(userLoginRequest);
 
 
+            //then
+            Assertions.assertEquals("newUser", result.userLoginDTO().username());
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 얻기(GET /api/user)")
+    class GetUser {
+        @Test
+        @DisplayName("성공 테스트")
+        void get_user_success_test() {
+            //given
+            UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository);
+            UserInfoDTO userInfoRequest = new UserInfoDTO(user);
+
+            //when
+            when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
+            when(userRepository.save(any())).thenReturn(user);
+            UserInfoResponse result = userService.getCurrentUser(userInfoRequest);
+
+
+            //then
+            Assertions.assertEquals("newUser", result.userInfoDTO().username());
+        }
+    }
 
 
 }

--- a/src/test/java/com/milktea/main/user/service/UserServiceTest.java
+++ b/src/test/java/com/milktea/main/user/service/UserServiceTest.java
@@ -1,8 +1,12 @@
 package com.milktea.main.user.service;
 
 import com.milktea.main.factory.UserMother;
-import com.milktea.main.user.dto.UserRegisterRequest;
-import com.milktea.main.user.dto.UserRegisterResponse;
+import com.milktea.main.user.dto.request.UserInfoDTO;
+import com.milktea.main.user.dto.request.UserLoginRequest;
+import com.milktea.main.user.dto.request.UserRegisterRequest;
+import com.milktea.main.user.dto.response.UserInfoResponse;
+import com.milktea.main.user.dto.response.UserLoginResponse;
+import com.milktea.main.user.dto.response.UserRegisterResponse;
 import com.milktea.main.user.entity.User;
 import com.milktea.main.user.repository.AuthorityRepository;
 import com.milktea.main.user.repository.UserRepository;

--- a/src/test/java/com/milktea/main/user/service/UserServiceTest.java
+++ b/src/test/java/com/milktea/main/user/service/UserServiceTest.java
@@ -46,7 +46,7 @@ public class UserServiceTest {
         userRepository = Mockito.mock(UserRepository.class);
         authorityRepository = Mockito.mock(AuthorityRepository.class);
         passwordEncoder = new BCryptPasswordEncoder();
-        UserService userService = new UserService(passwordEncoder, userRepository, authorityRepository, jwtTokenAdministrator);
+        userService = new UserService(passwordEncoder, userRepository, authorityRepository, jwtTokenAdministrator);
     }
 
     @Nested

--- a/src/test/java/com/milktea/main/user/service/UserServiceTest.java
+++ b/src/test/java/com/milktea/main/user/service/UserServiceTest.java
@@ -1,20 +1,27 @@
 package com.milktea.main.user.service;
 
 import com.milktea.main.factory.UserMother;
+import com.milktea.main.factory.WithCustomUser;
 import com.milktea.main.user.dto.request.UserInfoDTO;
 import com.milktea.main.user.dto.request.UserLoginRequest;
 import com.milktea.main.user.dto.request.UserRegisterRequest;
+import com.milktea.main.user.dto.request.UserUpdateRequest;
 import com.milktea.main.user.dto.response.UserInfoResponse;
 import com.milktea.main.user.dto.response.UserLoginResponse;
 import com.milktea.main.user.dto.response.UserRegisterResponse;
+import com.milktea.main.user.dto.response.UserUpdateResponse;
 import com.milktea.main.user.entity.User;
 import com.milktea.main.user.repository.AuthorityRepository;
 import com.milktea.main.user.repository.UserRepository;
 import com.milktea.main.util.exceptions.ValidationException;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
 import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -45,6 +52,7 @@ public class UserServiceTest {
         user = UserMother.user().build();
         userRepository = Mockito.mock(UserRepository.class);
         authorityRepository = Mockito.mock(AuthorityRepository.class);
+        jwtTokenAdministrator = Mockito.mock(JwtTokenAdministrator.class);
         passwordEncoder = new BCryptPasswordEncoder();
         userService = new UserService(passwordEncoder, userRepository, authorityRepository, jwtTokenAdministrator);
     }
@@ -134,6 +142,89 @@ public class UserServiceTest {
 
             //then
             Assertions.assertEquals("newUser", result.userInfoDTO().username());
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 업데이트하기(PUT /api/user)")
+    class Update {
+        private static Authentication auth;
+        @BeforeEach
+        void setup() {
+            auth = new EmailPasswordAuthentication(
+                    user.getEmail(),
+                    user.getPassword(),
+                    user.getAuthorities().stream()
+                            .map(authority -> new SimpleGrantedAuthority(authority.getName()))
+                            .toList()
+            );
+        }
+
+        @Test
+        @DisplayName("성공 테스트")
+        void update_user_success_test() {
+            //given
+            UserUpdateRequest.UserUpdateDTO userUpdateRequest = new UserUpdateRequest.UserUpdateDTO(null, "newUser2@naver.com", "update bio", null, null);
+
+
+            //when
+            when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
+            when(userRepository.findByEmail(eq("newUser2@naver.com"))).thenReturn(Optional.empty());
+            when(jwtTokenAdministrator.updateToken(any(), any(), any())).thenReturn("new Token");
+            UserUpdateResponse result = userService.updateUser(auth, userUpdateRequest, "old Token");
+
+            //then
+            Assertions.assertEquals("newUser2@naver.com", result.userUpdateDTO().email());
+            Assertions.assertEquals("update bio", result.userUpdateDTO().bio());
+            Assertions.assertEquals("new Token", result.userUpdateDTO().token());
+        }
+
+        @Test
+        @DisplayName("중복된 이메일 실패 테스트")
+        void update_user_duplicate_email_fail_test() {
+            //given
+            UserUpdateRequest.UserUpdateDTO userUpdateRequest = new UserUpdateRequest.UserUpdateDTO(null, "newUser2@naver.com", "update bio", null, null);
+            Authentication auth = new EmailPasswordAuthentication(
+                    user.getEmail(),
+                    user.getPassword(),
+                    user.getAuthorities().stream()
+                            .map(authority -> new SimpleGrantedAuthority(authority.getName()))
+                            .toList()
+            );
+
+            //when
+            //then
+            when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
+            when(userRepository.findByEmail(eq("newUser2@naver.com"))).thenReturn(Optional.of(UserMother.user()
+                    .withEmail("newUser2@naver.com")
+                    .build()));
+            when(jwtTokenAdministrator.updateToken(any(), any(), any())).thenReturn("new Token");
+
+            Assertions.assertThrows(ValidationException.class, () -> userService.updateUser(auth, userUpdateRequest, "old Token"));
+        }
+
+        @Test
+        @DisplayName("중복된 username 실패 테스트")
+        void update_user_duplicate_username_fail_test() {
+            //given
+            UserUpdateRequest.UserUpdateDTO userUpdateRequest = new UserUpdateRequest.UserUpdateDTO("newUser2", null, "update bio", null, null);
+            Authentication auth = new EmailPasswordAuthentication(
+                    user.getEmail(),
+                    user.getPassword(),
+                    user.getAuthorities().stream()
+                            .map(authority -> new SimpleGrantedAuthority(authority.getName()))
+                            .toList()
+            );
+
+            //when
+            //then
+            when(userRepository.findByEmail(eq("newUser@naver.com"))).thenReturn(Optional.of(user));
+            when(userRepository.findByUsername(eq("newUser2"))).thenReturn(Optional.of(UserMother.user()
+                    .withUsername("newUser2")
+                    .build()));
+            when(jwtTokenAdministrator.updateToken(any(), any(), any())).thenReturn("new Token");
+
+            Assertions.assertThrows(ValidationException.class, () -> userService.updateUser(auth, userUpdateRequest, "old Token"));
         }
     }
 

--- a/src/test/java/com/milktea/main/util/security/BoardUserDetailsServiceTest.java
+++ b/src/test/java/com/milktea/main/util/security/BoardUserDetailsServiceTest.java
@@ -42,7 +42,7 @@ public class BoardUserDetailsServiceTest {
 
         //then
         Assertions.assertNotNull(result);
-        Assertions.assertEquals("newUser", result.getUsername());
+        Assertions.assertEquals("newUser@naver.com", result.getUsername());
     }
 
     @Test

--- a/src/test/java/com/milktea/main/util/security/filter/InitialAuthenticationFilterTest.java
+++ b/src/test/java/com/milktea/main/util/security/filter/InitialAuthenticationFilterTest.java
@@ -4,6 +4,7 @@ package com.milktea.main.util.security.filter;
 import com.milktea.main.factory.UserMother;
 import com.milktea.main.user.entity.Authority;
 import com.milktea.main.user.entity.User;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
 import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import jakarta.servlet.ServletException;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +17,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -86,7 +86,7 @@ public class InitialAuthenticationFilterTest {
                     .map(SimpleGrantedAuthority::new)
                     .toList();
 
-            return new UsernamePasswordAuthenticationToken(
+            return new EmailPasswordAuthentication(
                     email,
                     password,
                     authorities);
@@ -95,11 +95,13 @@ public class InitialAuthenticationFilterTest {
 
     private static class MockJwtTokenAdministrator extends JwtTokenAdministrator {
         public MockJwtTokenAdministrator() {
-            super(null, null);
+            super(null, null, null);
         }
 
         @Override
         public String issueToken(Authentication returnAuthentication) {
+
+            log.debug(returnAuthentication.getName());
             return "test success token";
         }
     }

--- a/src/test/java/com/milktea/main/util/security/filter/InitialAuthenticationFilterTest.java
+++ b/src/test/java/com/milktea/main/util/security/filter/InitialAuthenticationFilterTest.java
@@ -4,6 +4,7 @@ package com.milktea.main.util.security.filter;
 import com.milktea.main.factory.UserMother;
 import com.milktea.main.user.entity.Authority;
 import com.milktea.main.user.entity.User;
+import com.milktea.main.util.security.jwt.JwtTokenAdministrator;
 import jakarta.servlet.ServletException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -34,7 +35,6 @@ public class InitialAuthenticationFilterTest {
 
     //Mock AuthenticationManager
     private static MockAuthenticationManager manager;
-    private static final String TEST_SIGNING_KEY = "adsfasfasfasdfasdfasfasdfasfasdfasdfasfdasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasfd";
 
     @BeforeEach
     void setup() {
@@ -50,7 +50,7 @@ public class InitialAuthenticationFilterTest {
     @DisplayName("email과 password가 일치하면 jwt 토큰을 반환한다")
     void correct_username_password_test() throws ServletException, IOException {
         //given
-        InitialAuthenticationFilter initialAuthenticationFilter = new InitialAuthenticationFilter(manager, TEST_SIGNING_KEY);
+        InitialAuthenticationFilter initialAuthenticationFilter = new InitialAuthenticationFilter(manager, new MockJwtTokenAdministrator());
         request.addHeader("content-type", "application/json");
         request.setContentType("application/json");
         request.setContent("""
@@ -90,6 +90,17 @@ public class InitialAuthenticationFilterTest {
                     email,
                     password,
                     authorities);
+        }
+    }
+
+    private static class MockJwtTokenAdministrator extends JwtTokenAdministrator {
+        public MockJwtTokenAdministrator() {
+            super(null, null);
+        }
+
+        @Override
+        public String issueToken(Authentication returnAuthentication) {
+            return "test success token";
         }
     }
 }

--- a/src/test/java/com/milktea/main/util/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/milktea/main/util/security/filter/JwtAuthenticationFilterTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.io.IOException;
-import io.jsonwebtoken.security.SignatureException;
 import java.util.Collection;
 
 @Slf4j
@@ -84,7 +83,7 @@ public class JwtAuthenticationFilterTest {
 
     private static class MockJwtTokenAdministrator extends JwtTokenAdministrator {
         public MockJwtTokenAdministrator() {
-            super(null, null);
+            super(null, null, null);
         }
 
         @Override

--- a/src/test/java/com/milktea/main/util/security/jwt/JwtTokenAdministratorTest.java
+++ b/src/test/java/com/milktea/main/util/security/jwt/JwtTokenAdministratorTest.java
@@ -1,6 +1,7 @@
 package com.milktea.main.util.security.jwt;
 
 import com.milktea.main.factory.UserMother;
+import com.milktea.main.util.exceptions.JwtAuthenticationException;
 import com.milktea.main.util.security.BoardUserDetails;
 import com.milktea.main.util.security.EmailPasswordAuthentication;
 import io.jsonwebtoken.Claims;
@@ -107,7 +108,7 @@ public class JwtTokenAdministratorTest {
 
             //when
             //then
-            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+            Assertions.assertThrows(JwtAuthenticationException.class, () -> jwtTokenAdministrator.verifyToken(token));
         }
 
         @Test
@@ -123,7 +124,7 @@ public class JwtTokenAdministratorTest {
             Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
 
             //then
-            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+            Assertions.assertThrows(JwtAuthenticationException.class, () -> jwtTokenAdministrator.verifyToken(token));
         }
 
         @Test
@@ -136,7 +137,7 @@ public class JwtTokenAdministratorTest {
             Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
 
             //then
-            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+            Assertions.assertThrows(JwtAuthenticationException.class, () -> jwtTokenAdministrator.verifyToken(token));
         }
 
         @Test

--- a/src/test/java/com/milktea/main/util/security/jwt/JwtTokenAdministratorTest.java
+++ b/src/test/java/com/milktea/main/util/security/jwt/JwtTokenAdministratorTest.java
@@ -1,0 +1,190 @@
+package com.milktea.main.util.security.jwt;
+
+import com.milktea.main.factory.UserMother;
+import com.milktea.main.util.security.BoardUserDetails;
+import com.milktea.main.util.security.EmailPasswordAuthentication;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.ServletException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenAdministratorTest {
+    private JwtTokenAdministrator jwtTokenAdministrator;
+
+    private JwtTokenBlackListRepository jwtTokenBlackListRepository;
+
+    private final String signingKey = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+
+    private BoardUserDetails userDetails;
+
+    private Clock clock;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        /*
+        clock = Clock.fixed(
+                Instant.parse("2024-01-01T10:00:00Z"),
+                ZoneOffset.ofHours(9)); //seoul;
+         */
+        clock = Mockito.mock(Clock.class);
+        userDetails = new BoardUserDetails(UserMother.user().build());
+        jwtTokenBlackListRepository = Mockito.mock(JwtTokenBlackListRepository.class);
+        jwtTokenAdministrator = new JwtTokenAdministrator(signingKey, jwtTokenBlackListRepository, clock);
+    }
+
+    @Nested
+    @DisplayName("토큰 발급")
+    class issue {
+        @Test
+        @DisplayName("성공 테스트")
+        void issue_token_success_test() {
+            //given
+            Authentication auth = new EmailPasswordAuthentication(
+                    userDetails.getUsername(),
+                    userDetails.getPassword(),
+                    userDetails.getAuthorities()
+            );
+
+            //Clock Mock
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+
+            //when
+            String token = jwtTokenAdministrator.issueToken(auth);
+
+            //then
+            log.debug(token);
+            Assertions.assertNotNull(token);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class verify {
+
+        @Test
+        @DisplayName("성공 테스트")
+        void verify_token_success_test() throws ServletException {
+            //given
+            //expired time이 "2024-01-01T10:00:00Z"이고 test User일 때 토큰
+            token = "Token eyJhbGciOiJIUzM4NCJ9." +
+                    "eyJleHAiOjE3MDQxMDUwMDAsImVtYWlsIjoibmV3VXNlckBuYXZlci5jb20iLCJhdXRob3JpdGllcyI6IlVTRVIifQ." +
+                    "EsW_BcUyYIhPwSftKcqp_8vyX20LnRw-gB6shFG21MJ9Nx7QK_1kDBCEGA3X48rf";
+
+            //when
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+            Mockito.when(jwtTokenBlackListRepository.findById(any())).thenReturn(Optional.empty());
+            Claims claims = jwtTokenAdministrator.verifyToken(token);
+
+            //then
+            Assertions.assertEquals("newUser@naver.com", claims.get("email", String.class));
+        }
+
+        @Test
+        @DisplayName("토큰 만료 실패 테스트")
+        void verify_token_expired_fail_test() throws ServletException {
+            //given
+            //expired time이 "2024-01-01T10:00:00Z"이고 test User일 때 토큰
+            token = "Token eyJhbGciOiJIUzM4NCJ9." +
+                    "eyJleHAiOjE3MDQxMDUwMDAsImVtYWlsIjoibmV3VXNlckBuYXZlci5jb20iLCJhdXRob3JpdGllcyI6IlVTRVIifQ." +
+                    "EsW_BcUyYIhPwSftKcqp_8vyX20LnRw-gB6shFG21MJ9Nx7QK_1kDBCEGA3X48rf";
+
+            //현재 시간 변경(생성 시간은 2024-01-01T10:00:00Z 현재 시간은 이로부터 한시간 뒤)
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T11:00:00Z"));
+
+            //when
+            //then
+            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+        }
+
+        @Test
+        @DisplayName("토큰 잘못된 서명 실패 테스트")
+        void verify_token_invalid_signature_fail_test() throws ServletException {
+            //given
+            //expired time이 "2024-01-01T10:00:00Z"이고 test User일 때 토큰에서 서명 수정 없이 payload의 이메일만 변경
+            token = "Token eyJhbGciOiJIUzM4NCJ9." +
+                    "eyJleHAiOjE3MDQxMDUwMDAsImVtYWlsIjoibmV3VXNlcjJAbmF2ZXIuY29tIiwiYXV0aG9yaXRpZXMiOiJVU0VSIn0." +
+                    "EsW_BcUyYIhPwSftKcqp_8vyX20LnRw-gB6shFG21MJ9Nx7QK_1kDBCEGA3X48rf";
+
+            //when
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+
+            //then
+            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰 형식 실패 테스트")
+        void verify_token_invalid_format_fail_test() throws ServletException {
+            //given
+            token = "Token test token";
+
+            //when
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+
+            //then
+            Assertions.assertThrows(ServletException.class, () -> jwtTokenAdministrator.verifyToken(token));
+        }
+
+        @Test
+        @DisplayName("토큰 블랙리스트 실패 테스트")
+        void verify_token_blacklist_fail_test() throws ServletException {
+            //given
+            //expired time이 "2024-01-01T10:00:00Z"이고 test User일 때 토큰
+            token = "Token eyJhbGciOiJIUzM4NCJ9." +
+                    "eyJleHAiOjE3MDQxMDUwMDAsImVtYWlsIjoibmV3VXNlckBuYXZlci5jb20iLCJhdXRob3JpdGllcyI6IlVTRVIifQ." +
+                    "EsW_BcUyYIhPwSftKcqp_8vyX20LnRw-gB6shFG21MJ9Nx7QK_1kDBCEGA3X48rf";
+
+            //when
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+            Mockito.when(jwtTokenBlackListRepository.findById(any())).thenReturn(Optional.of(new JwtTokenBlackList(
+                    userDetails.getUsername(),
+                    token.replaceFirst("Token ", "")
+                    )));
+
+            //then
+            Assertions.assertThrows(BadCredentialsException.class, () -> jwtTokenAdministrator.verifyToken(token));
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 업데이트")
+    class update {
+        @Test
+        @DisplayName("성공 테스트")
+        void update_token_success_test() {
+            //given
+            token = "Token eyJhbGciOiJIUzM4NCJ9." +
+                    "eyJleHAiOjE3MDQxMDUwMDAsImVtYWlsIjoibmV3VXNlckBuYXZlci5jb20iLCJhdXRob3JpdGllcyI6IlVTRVIifQ." +
+                    "EsW_BcUyYIhPwSftKcqp_8vyX20LnRw-gB6shFG21MJ9Nx7QK_1kDBCEGA3X48rf";
+
+            Authentication auth = new EmailPasswordAuthentication(
+                    userDetails.getUsername(),
+                    userDetails.getPassword(),
+                    userDetails.getAuthorities()
+            );
+            String newEmail = "newUser2@naver.com";
+
+            //when
+            Mockito.when(clock.instant()).thenReturn(Instant.parse("2024-01-01T10:00:00Z"));
+            String newToken = jwtTokenAdministrator.updateToken(auth, newEmail, token);
+
+            //then
+            Assertions.assertNotEquals(newToken, token);
+            log.debug(newToken);
+        }
+    }
+}

--- a/src/test/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepositoryTest.java
+++ b/src/test/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.milktea.main.util.security.jwt;
 
-import com.milktea.main.util.security.config.EmbeddedRedisConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,13 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.Optional;
 
-@SpringBootTest(classes = EmbeddedRedisConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) //테스트 메서드마다 데이터베이스 초기화
 @Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class JwtTokenBlackListRepositoryTest {
     @Autowired
     private JwtTokenBlackListRepository jwtTokenBlackListRepository;
@@ -25,6 +22,7 @@ public class JwtTokenBlackListRepositoryTest {
     void setup() {
         blackList = new JwtTokenBlackList("newUser@naver.com", "jwtToken");
     }
+    //Embedded Redis를 실행하기 전에 Redis를 서비스 종료해야함! -> 포트 충돌
     @Test
     @DisplayName("save 테스트")
     public void blacklist_save_success_test() {

--- a/src/test/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepositoryTest.java
+++ b/src/test/java/com/milktea/main/util/security/jwt/JwtTokenBlackListRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.milktea.main.util.security.jwt;
+
+import com.milktea.main.util.security.config.EmbeddedRedisConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Optional;
+
+@SpringBootTest(classes = EmbeddedRedisConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) //테스트 메서드마다 데이터베이스 초기화
+@Slf4j
+public class JwtTokenBlackListRepositoryTest {
+    @Autowired
+    private JwtTokenBlackListRepository jwtTokenBlackListRepository;
+
+    private static JwtTokenBlackList blackList;
+
+    @BeforeEach
+    void setup() {
+        blackList = new JwtTokenBlackList("newUser@naver.com", "jwtToken");
+    }
+    @Test
+    @DisplayName("save 테스트")
+    public void blacklist_save_success_test() {
+        //given
+        //when
+        JwtTokenBlackList jwtTokenBlackList = jwtTokenBlackListRepository.save(blackList);
+
+        //then
+        Assertions.assertEquals("jwtToken", jwtTokenBlackList.getTokenValue());
+    }
+
+    @Test
+    @DisplayName("findById 성공 테스트")
+    public void blacklist_findById_success_test() {
+        //given
+        jwtTokenBlackListRepository.save(blackList);
+
+        //when
+        Optional<JwtTokenBlackList> optionalBlackList = jwtTokenBlackListRepository.findById("newUser@naver.com");
+
+        //then
+        Assertions.assertTrue(optionalBlackList.isPresent());
+        Assertions.assertEquals("jwtToken", optionalBlackList.get().getTokenValue());
+    }
+
+    @Test
+    @DisplayName("findByUsername 실패 테스트")
+    public void user_findByUsername_fail_test() {
+        //given
+
+        //when
+        Optional<JwtTokenBlackList> optionalBlackList = jwtTokenBlackListRepository.findById("newUser@naver.com");
+
+        //then
+        Assertions.assertTrue(optionalBlackList.isEmpty());
+    }
+}


### PR DESCRIPTION
close #9 

## 요약
유저 정보 얻기, 유저 정보 업데이트 기능 개발 및 테스트

## 한일
### 현재 유저 정보 얻기 기능 개발 및 테스트
- jwt 토큰으로 현재 유저 정보를 얻는 기능 구현

### 유저 정보 수정하기 기능 개발 및 테스트
- DB에 저장된 기존의 유저 정보를 수정하고 토큰을 갱신

## Postman Test
### 유저 정보 얻기
![image](https://github.com/MilkTea24/realworld-backend/assets/83940605/e1860cb8-9711-4602-b82e-e5b33050b5d8)


### 유저 정보 업데이트하기
![image](https://github.com/MilkTea24/realworld-backend/assets/83940605/b8d3a5c2-cb64-439b-a7aa-5217638c0057)


## JaCoCo Report
![image](https://github.com/MilkTea24/realworld-backend/assets/83940605/cef36a9b-f546-41b8-9ba0-d2b6245b0815)

